### PR TITLE
chore(Burnex): Update library to version 2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule EctoCommons.MixProject do
       {:ecto, "~> 3.4"},
 
       # Used by email validator
-      {:burnex, "~> 1.0"},
+      {:burnex, "~> 2.0"},
       # Used by Luhn validator
       {:luhn, "~> 0.3.0"},
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
-  "burnex": {:hex, :burnex, "1.2.1", "ad079fd57cb15ac28db6511b37613494359d684d6675ccf1617bed43d9de8fd9", [:mix], [], "hexpm", "f1a52bb18277f679f0494b925ba00a7d22d637bcc1531634662e7fff7b156497"},
+  "burnex": {:hex, :burnex, "2.0.0", "70b9b2b290b901d8dc2c67142d157814c76a9fea7d441ef373ca4f12f0941967", [:mix], [], "hexpm", "3cbc4344674e7c3e42bc8b92d43887a35c0b321cc01f7798eb6e382eff66a954"},
   "certifi": {:hex, :certifi, "2.5.2", "b7cfeae9d2ed395695dd8201c57a2d019c0c43ecaf8b8bcb9320b40d6662f340", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm", "3b3b5f36493004ac3455966991eaf6e768ce9884693d9968055aeeeb1e575040"},
   "credo": {:hex, :credo, "1.1.5", "caec7a3cadd2e58609d7ee25b3931b129e739e070539ad1a0cd7efeeb47014f4", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "d0bbd3222607ccaaac5c0340f7f525c627ae4d7aee6c8c8c108922620c5b6446"},
   "credo_contrib": {:hex, :credo_contrib, "0.2.0", "032af0f1f096ddc7a2128fa475fdbb34f73563ca3fb2d6f826b0fa343b76d507", [:mix], [{:credo, "~> 1.0", [hex: :credo, repo: "hexpm", optional: false]}], "hexpm", "afebe9dd51371c121aab3eb14b1c70316be4345b0333fdcedb5d6404a06be309"},


### PR DESCRIPTION
@achedeuzot Updates burnex to version 2.0 which includes a longer list of burner email domains and a much faster method of checking if a domain is from a burner address. No code changes are necessary to upgrade.