### PR TITLE
ci: new matrix for updated versions of otp/elixir

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,20 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: ["20.3", "21.3", "22.3", "23.2"]
-        elixir: ["1.9.4", "1.10.4", "1.11.3"]
-        exclude:
-          - otp: "23.2"
-            elixir: "1.9.4"
-          - otp: "20.3"
-            elixir: "1.10.4"
-          - otp: "23.2"
-            elixir: "1.10.4"
-          - otp: "20.3"
-            elixir: "1.11.3"
-          # The couple OTP 21.3 and elixir 1.11.3 is extermely slow for some reason
-          - otp: "21.3"
-            elixir: "1.11.3"
+        otp: ["21.3", "22.3", "23.3", "24.3", "25.3"]
+        elixir: ["1.10.4", "1.11.4", "1.12.3", "1.13.4", "1.14.4"]
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
An attempt to address this https://github.com/achedeuzot/ecto_commons/issues/66#issuecomment-1477514243 TBH, it felt terrible removing the excludes, but I wasn't quite sure what their intent was. This is largely an initial attempt to see if the tests will run/pass. Then I can add the excludes back if it makes sense. 

Stumbled upon your library and EmailValidate and would like to see it continue on as I'm making it a part of my app. Hope this helps and doesn't add too much noise.