### PR TITLE
Fix validation name

### DIFF
--- a/lib/validators/date.ex
+++ b/lib/validators/date.ex
@@ -36,7 +36,7 @@ defmodule EctoCommons.DateValidator do
       iex> params = %{birthdate: ~D[2016-05-24]}
       iex> Ecto.Changeset.cast({%{}, types}, params, Map.keys(types))
       ...> |> validate_date(:birthdate, is: ~D[2017-05-24])
-      #Ecto.Changeset<action: nil, changes: %{birthdate: ~D[2016-05-24]}, errors: [birthdate: {"should be %{is}.", [validation: :datetime, kind: :is]}], data: %{}, valid?: false>
+      #Ecto.Changeset<action: nil, changes: %{birthdate: ~D[2016-05-24]}, errors: [birthdate: {"should be %{is}.", [validation: :date, kind: :is]}], data: %{}, valid?: false>
 
       # Using :is with :delta to ensure a date is near another another date
       iex> types = %{birthdate: :date}
@@ -49,7 +49,7 @@ defmodule EctoCommons.DateValidator do
       iex> params = %{birthdate: ~D[2016-04-24]}
       iex> Ecto.Changeset.cast({%{}, types}, params, Map.keys(types))
       ...> |> validate_date(:birthdate, is: ~D[2016-05-24], delta: 7)
-      #Ecto.Changeset<action: nil, changes: %{birthdate: ~D[2016-04-24]}, errors: [birthdate: {"should be %{is}.", [validation: :datetime, kind: :is]}], data: %{}, valid?: false>
+      #Ecto.Changeset<action: nil, changes: %{birthdate: ~D[2016-04-24]}, errors: [birthdate: {"should be %{is}.", [validation: :date, kind: :is]}], data: %{}, valid?: false>
 
       # Using :before to ensure date is before given date
       iex> types = %{birthdate: :date}
@@ -62,7 +62,7 @@ defmodule EctoCommons.DateValidator do
       iex> params = %{birthdate: ~D[2016-05-24]}
       iex> Ecto.Changeset.cast({%{}, types}, params, Map.keys(types))
       ...> |> validate_date(:birthdate, before: ~D[2015-05-24])
-      #Ecto.Changeset<action: nil, changes: %{birthdate: ~D[2016-05-24]}, errors: [birthdate: {"should be before %{before}.", [validation: :datetime, kind: :before]}], data: %{}, valid?: false>
+      #Ecto.Changeset<action: nil, changes: %{birthdate: ~D[2016-05-24]}, errors: [birthdate: {"should be before %{before}.", [validation: :date, kind: :before]}], data: %{}, valid?: false>
 
       iex> types = %{birthdate: :date}
       iex> params = %{birthdate: ~D[2016-05-24]}
@@ -74,7 +74,7 @@ defmodule EctoCommons.DateValidator do
       iex> params = %{birthdate: ~D[3000-05-24]}
       iex> Ecto.Changeset.cast({%{}, types}, params, Map.keys(types))
       ...> |> validate_date(:birthdate, before: :utc_today)
-      #Ecto.Changeset<action: nil, changes: %{birthdate: ~D[3000-05-24]}, errors: [birthdate: {"should be before %{before}.", [validation: :datetime, kind: :before]}], data: %{}, valid?: false>
+      #Ecto.Changeset<action: nil, changes: %{birthdate: ~D[3000-05-24]}, errors: [birthdate: {"should be before %{before}.", [validation: :date, kind: :before]}], data: %{}, valid?: false>
 
       # Using :after to ensure date is after given date
       iex> types = %{birthdate: :date}
@@ -87,7 +87,7 @@ defmodule EctoCommons.DateValidator do
       iex> params = %{birthdate: ~D[2016-05-24]}
       iex> Ecto.Changeset.cast({%{}, types}, params, Map.keys(types))
       ...> |> validate_date(:birthdate, after: ~D[2017-05-24])
-      #Ecto.Changeset<action: nil, changes: %{birthdate: ~D[2016-05-24]}, errors: [birthdate: {"should be after %{after}.", [validation: :datetime, kind: :after]}], data: %{}, valid?: false>
+      #Ecto.Changeset<action: nil, changes: %{birthdate: ~D[2016-05-24]}, errors: [birthdate: {"should be after %{after}.", [validation: :date, kind: :after]}], data: %{}, valid?: false>
 
       iex> types = %{birthdate: :date}
       iex> params = %{birthdate: ~D[3000-05-24]}
@@ -99,14 +99,14 @@ defmodule EctoCommons.DateValidator do
       iex> params = %{birthdate: ~D[1000-05-24]}
       iex> Ecto.Changeset.cast({%{}, types}, params, Map.keys(types))
       ...> |> validate_date(:birthdate, after: :utc_today)
-      #Ecto.Changeset<action: nil, changes: %{birthdate: ~D[1000-05-24]}, errors: [birthdate: {"should be after %{after}.", [validation: :datetime, kind: :after]}], data: %{}, valid?: false>
+      #Ecto.Changeset<action: nil, changes: %{birthdate: ~D[1000-05-24]}, errors: [birthdate: {"should be after %{after}.", [validation: :date, kind: :after]}], data: %{}, valid?: false>
 
   """
 
   import Ecto.Changeset
 
   def validate_date(changeset, field, opts \\ []) do
-    validate_change(changeset, field, {:datetime, opts}, fn
+    validate_change(changeset, field, {:date, opts}, fn
       _, value ->
         is = get_validation_value(opts[:is])
         afterr = get_validation_value(opts[:after])
@@ -126,7 +126,7 @@ defmodule EctoCommons.DateValidator do
   defp wrong_date(%Date{} = value, is, nil, opts) do
     case Date.compare(value, is) do
       :eq -> nil
-      _ -> {message(opts, "should be %{is}."), validation: :datetime, kind: :is}
+      _ -> {message(opts, "should be %{is}."), validation: :date, kind: :is}
     end
   end
 
@@ -138,7 +138,7 @@ defmodule EctoCommons.DateValidator do
       _ ->
         case abs(Date.diff(value, is)) do
           val when val > delta ->
-            {message(opts, "should be %{is}."), validation: :datetime, kind: :is}
+            {message(opts, "should be %{is}."), validation: :date, kind: :is}
 
           _ ->
             nil
@@ -151,7 +151,7 @@ defmodule EctoCommons.DateValidator do
   defp too_soon(%Date{} = value, afterr, opts) do
     case Date.compare(value, afterr) do
       :gt -> nil
-      _ -> {message(opts, "should be after %{after}."), validation: :datetime, kind: :after}
+      _ -> {message(opts, "should be after %{after}."), validation: :date, kind: :after}
     end
   end
 
@@ -160,7 +160,7 @@ defmodule EctoCommons.DateValidator do
   defp too_late(%Date{} = value, before, opts) do
     case Date.compare(value, before) do
       :lt -> nil
-      _ -> {message(opts, "should be before %{before}."), validation: :datetime, kind: :before}
+      _ -> {message(opts, "should be before %{before}."), validation: :date, kind: :before}
     end
   end
 

--- a/test/unit/validators/date_test.exs
+++ b/test/unit/validators/date_test.exs
@@ -13,7 +13,7 @@ defmodule EctoCommons.DateValidatorTest do
 
     # Sad path
     {~D[2015-05-25], ~D[2015-05-24],
-     [{:birthdate, {"should be before %{before}.", [validation: :datetime, kind: :before]}}]}
+     [{:birthdate, {"should be before %{before}.", [validation: :date, kind: :before]}}]}
   ]
 
   for {input, before, expected_errors} <- @parameters_before do
@@ -38,7 +38,7 @@ defmodule EctoCommons.DateValidatorTest do
 
     # Sad path
     {~D[2015-05-23], ~D[2015-05-24],
-     [{:birthdate, {"should be after %{after}.", [validation: :datetime, kind: :after]}}]}
+     [{:birthdate, {"should be after %{after}.", [validation: :date, kind: :after]}}]}
   ]
 
   for {input, afterr, expected_errors} <- @parameters_after do
@@ -62,7 +62,7 @@ defmodule EctoCommons.DateValidatorTest do
       Ecto.Changeset.cast({%{}, types}, params, Map.keys(types))
       |> validate_date(:birthdate, after: ~D[2015-05-25], before: ~D[2015-05-25])
 
-    assert [{:birthdate, {"should be after %{after}.", [validation: :datetime, kind: :after]}}] ==
+    assert [{:birthdate, {"should be after %{after}.", [validation: :date, kind: :after]}}] ==
              result.errors
   end
 end


### PR DESCRIPTION
Corrects the changeset metadata for `validate_date/3` validations from `:datetime` to `:date`