### PR TITLE
Make Burnex an optional dependency

### DIFF
--- a/lib/validators/email.ex
+++ b/lib/validators/email.ex
@@ -10,8 +10,8 @@ defmodule EctoCommons.EmailValidator do
     their `type="email"` input fields. This is the default as it corresponds to most use-cases. It is quite strict
     without being too narrow. It does not support unicode emails though. If you need better internationalization,
     please use the `:pow` check as it is more flexible with international emails. Defaults to enabled.
-  - `:burner`: Checks if the email given is a burner email provider (uses the `Burnex` lib under the hood).
-    When enabled, will reject temporary email providers. Defaults to disabled.
+  - `:burner`: Checks if the email given is a burner email provider (uses the `Burnex` lib under the hood,
+    so make sure to add it to your dependencies). When enabled, will reject temporary email providers. Defaults to disabled.
   - `:check_mx_record`: Checks if the email domain exists in the DNS system (can be a bit slow).
   - `:pow`: Checks the email using the [`pow`](https://hex.pm/packages/pow) logic. Defaults to disabled.
     The rules are the following:

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule EctoCommons.MixProject do
       {:ecto, "~> 3.4"},
 
       # Used by email validator
-      {:burnex, "~> 3.0"},
+      {:burnex, "~> 3.0", optional: true},
       # Used by Luhn validator
       {:luhn, "~> 0.3.0"},
       # Used by phone number validator


### PR DESCRIPTION
Hi 👋  and thanks for the great library!

This PR makes Burnex an optional dependency.  The reasoning behind this is that for users who don't use `burner` and `check_mx_record` checks or even email validator at all, it doesn't make much sense to have burnex in their deps. In fact, it may even cause some headache as it [pins](https://github.com/Betree/burnex/blob/7a66f17017d140e25e4df1c4e9fbc43b73656a91/mix.exs#L40) `dns` package to `"~> 2.2.0"` with latest version being `2.4.0`. `Burnex` was last updated 3 years ago and normally that would be ok, but for a library that depends on regularly updated [upstream list of bad emails](https://github.com/wesbos/burner-email-providers), it's concerning.