### PR TITLE
Make messages configurable

### DIFF
--- a/lib/validators/date.ex
+++ b/lib/validators/date.ex
@@ -102,7 +102,7 @@ defmodule EctoCommons.DateValidator do
   defp wrong_date(%Date{} = value, is, nil, opts) do
     case Date.compare(value, is) do
       :eq -> nil
-      _ -> {message(opts, "should be %{is}."), validation: :date, kind: :is, is: is}
+      _ -> {message(opts, :message, "should be %{is}."), validation: :date, kind: :is, is: is}
     end
   end
 
@@ -114,7 +114,7 @@ defmodule EctoCommons.DateValidator do
       _ ->
         case abs(Date.diff(value, is)) do
           val when val > delta ->
-            {message(opts, "should be %{is}."), validation: :date, kind: :is, is: is}
+            {message(opts, :message, "should be %{is}."), validation: :date, kind: :is, is: is}
 
           _ ->
             nil
@@ -127,7 +127,7 @@ defmodule EctoCommons.DateValidator do
   defp too_soon(%Date{} = value, afterr, opts) do
     case Date.compare(value, afterr) do
       :gt -> nil
-      _ -> {message(opts, "should be after %{after}."), validation: :date, kind: :after, after: afterr}
+      _ -> {message(opts, :message, "should be after %{after}."), validation: :date, kind: :after, after: afterr}
     end
   end
 
@@ -136,7 +136,7 @@ defmodule EctoCommons.DateValidator do
   defp too_late(%Date{} = value, before, opts) do
     case Date.compare(value, before) do
       :lt -> nil
-      _ -> {message(opts, "should be before %{before}."), validation: :date, kind: :before, before: before}
+      _ -> {message(opts, :message, "should be before %{before}."), validation: :date, kind: :before, before: before}
     end
   end
 

--- a/lib/validators/date_time.ex
+++ b/lib/validators/date_time.ex
@@ -126,7 +126,7 @@ defmodule EctoCommons.DateTimeValidator do
   defp wrong_datetime(%DateTime{} = value, is, nil, opts) do
     case DateTime.compare(value, is) do
       :eq -> nil
-      _ -> {message(opts, "should be %{is}."), validation: :datetime, kind: :is}
+      _ -> {message(opts, :message, "should be %{is}."), validation: :datetime, kind: :is}
     end
   end
 

--- a/lib/validators/email.ex
+++ b/lib/validators/email.ex
@@ -85,7 +85,7 @@ defmodule EctoCommons.EmailValidator do
       Enum.reduce(checks, [], fn check, errors ->
         case do_validate_email(value, check) do
           :ok -> errors
-          {:error, msg} -> [{field, {message(opts, msg), [validation: :email]}} | errors]
+          {:error, msg} -> [{field, {message(opts, :message, msg), [validation: :email]}} | errors]
         end
       end)
       |> List.flatten()

--- a/lib/validators/phone_number.ex
+++ b/lib/validators/phone_number.ex
@@ -51,7 +51,7 @@ defmodule EctoCommons.PhoneNumberValidator do
         []
       else
         _err ->
-          [{field, {message(opts, "is not a valid phone number"), [validation: :phone_number]}}]
+          [{field, {message(opts, :message, "is not a valid phone number"), [validation: :phone_number]}}]
       end
     end)
   end

--- a/lib/validators/postal_code.ex
+++ b/lib/validators/postal_code.ex
@@ -60,7 +60,7 @@ defmodule EctoCommons.PostalCodeValidator do
           []
 
         false ->
-          [{field, {message(opts, "is not a valid postal code"), [validation: :postal_code]}}]
+          [{field, {message(opts, :message, "is not a valid postal code"), [validation: :postal_code]}}]
       end
     end)
   end

--- a/lib/validators/social_security.ex
+++ b/lib/validators/social_security.ex
@@ -58,7 +58,7 @@ defmodule EctoCommons.SocialSecurityValidator do
           false ->
             [
               {field,
-               {message(opts, "is not a valid social security number"),
+               {message(opts, :message, "is not a valid social security number"),
                 [validation: :social_security]}}
             ]
 
@@ -69,7 +69,7 @@ defmodule EctoCommons.SocialSecurityValidator do
         _e ->
           [
             {field,
-             {message(opts, "is not a valid social security number"),
+             {message(opts, :message, "is not a valid social security number"),
               [validation: :social_security]}}
           ]
       end

--- a/lib/validators/string.ex
+++ b/lib/validators/string.ex
@@ -100,7 +100,7 @@ defmodule EctoCommons.StringValidator do
 
   defp wrong_prefix(value, prefix, opts) do
     unless String.starts_with?(value, prefix) do
-      {message(opts, "is not prefixed by %{prefix}."), validation: :has_prefix}
+      {message(opts, :message, "is not prefixed by %{prefix}."), validation: :has_prefix}
     else
       nil
     end

--- a/lib/validators/time.ex
+++ b/lib/validators/time.ex
@@ -102,7 +102,7 @@ defmodule EctoCommons.TimeValidator do
   defp wrong_time(%Time{} = value, is, nil, opts) do
     case Time.compare(value, is) do
       :eq -> nil
-      _ -> {message(opts, "should be %{is}."), validation: :time, kind: :is}
+      _ -> {message(opts, :message, "should be %{is}."), validation: :time, kind: :is}
     end
   end
 
@@ -114,7 +114,7 @@ defmodule EctoCommons.TimeValidator do
       _ ->
         case abs(Time.diff(value, is)) do
           val when val > delta ->
-            {message(opts, "should be %{is}."), validation: :time, kind: :is}
+            {message(opts, :message, "should be %{is}."), validation: :time, kind: :is}
 
           _ ->
             nil
@@ -127,7 +127,7 @@ defmodule EctoCommons.TimeValidator do
   defp too_soon(%Time{} = value, afterr, opts) do
     case Time.compare(value, afterr) do
       :gt -> nil
-      _ -> {message(opts, "should be after %{after}."), validation: :time, kind: :after}
+      _ -> {message(opts, :message, "should be after %{after}."), validation: :time, kind: :after}
     end
   end
 
@@ -136,7 +136,7 @@ defmodule EctoCommons.TimeValidator do
   defp too_late(%Time{} = value, before, opts) do
     case Time.compare(value, before) do
       :lt -> nil
-      _ -> {message(opts, "should be before %{before}."), validation: :time, kind: :before}
+      _ -> {message(opts, :message, "should be before %{before}."), validation: :time, kind: :before}
     end
   end
 

--- a/lib/validators/url.ex
+++ b/lib/validators/url.ex
@@ -59,7 +59,7 @@ defmodule EctoCommons.URLValidator do
 
       case do_validate_url(value, parsed, checks) do
         :ok -> []
-        :error -> [{field, {message(opts, "is not a valid url"), [validation: :url]}}]
+        :error -> [{field, {message(opts, :message, "is not a valid url"), [validation: :url]}}]
       end
     end)
   end


### PR DESCRIPTION
I think this was the intention but as you're not passing an atom to `Keyword.get`, it makes it impossible to override the message.

A gettext integration would be highly appreciated, but for now, this should be sufficient.